### PR TITLE
Bugfix/upsert issues

### DIFF
--- a/src/athlon_flex_notifier/models/base_model.py
+++ b/src/athlon_flex_notifier/models/base_model.py
@@ -3,10 +3,9 @@ from functools import cached_property
 from typing import TypeVar
 
 from kink import di, inject
-from sqlalchemy import Engine, select
-from sqlmodel import Field, Session, SQLModel
-
-from athlon_flex_notifier.utils import now
+from sqlalchemy import DateTime, Engine, inspect, select
+from sqlalchemy.dialects.postgresql import insert
+from sqlmodel import Field, Relationship, Session, SQLModel, func
 
 T = TypeVar("T", bound="BaseModel")
 
@@ -17,16 +16,56 @@ class BaseModel(SQLModel):
     Extends the SQLModel class with additional methods.
     """
 
-    created_at: datetime | None = Field(default=now(), nullable=False, exclude=True)
-    updated_at: datetime | None = Field(default_factory=now, nullable=False)
+    created_at: datetime | None = Field(
+        exclude=True,
+        default=None,
+        sa_type=DateTime(timezone=True),
+        sa_column_kwargs={"server_default": func.now()},
+    )
+    updated_at: datetime | None = Field(
+        exclude=True,
+        default=None,
+        sa_type=DateTime(timezone=True),
+        sa_column_kwargs={
+            "onupdate": func.now(),
+            "server_default": func.now(),
+            "server_onupdate": func.now(),
+        },
+    )
 
-    @staticmethod
-    def upsert(*entities: T) -> list[T]:
+    @classmethod
+    def upsert(cls, *entities: T) -> list[T]:
         """Upsert multiple entities into the database."""
+        # https://stackoverflow.com/questions/25955200/sqlalchemy-performing-a-bulk-upsert-if-exists-update-else-insert-in-postgr
+        new_entities = []
+        for entity in entities:
+            # entity.first_vehicle_id = "test" + str(entity.first_vehicle_id)
+            new_entities.append(entity)
+        data = [entity.model_dump() for entity in new_entities]
         with Session(di["database"], expire_on_commit=False) as session:
-            merged_entities = [session.merge(entity) for entity in entities]
+            # todo: fix issue: updated_at not updated
+            cols = set(cls.keys()) - set(cls.primary_keys()) - {"created_at"}
+            stmt = insert(cls).values(data)
+            stmt = stmt.on_conflict_do_update(
+                index_elements=cls.primary_keys(),
+                set_={col: getattr(stmt.excluded, col) for col in cols},
+            )
+            session.exec(stmt)
             session.commit()
-        return merged_entities
+        return entities
+
+    @classmethod
+    def upsert_relationships(cls: T, *entities: T) -> list[T]:
+        relationships = T.relationships
+        for relationship in relationships:
+            cls.upsert_relationships(*entities, relationship=relationship)
+
+    @classmethod
+    def upsert_relationships(
+        cls: T, *entities: T, relationship: Relationship
+    ) -> list[T]:
+        childs = [entity.getattr(relationship.key) for entity in entities]
+        test = ""
 
     @classmethod
     @inject
@@ -35,12 +74,22 @@ class BaseModel(SQLModel):
         with Session(database) as session:
             return [item[0] for item in session.exec(select(cls)).unique().all()]
 
-    @cached_property
-    def primary_keys(self) -> list[str]:
+    @classmethod
+    def primary_keys(cls) -> list[str]:
         """Get the primary keys of the entity."""
-        return [key.key for key in self.__table__.primary_key.columns]
+        return [key.key for key in cls.__table__.primary_key.columns]
+
+    @classmethod
+    def keys(cls) -> list[str]:
+        """Get the keys of the entity."""
+        return [key.key for key in cls.__table__.c]
 
     @cached_property
     def primary_key_values(self) -> list[str]:
         """Get the primary key values of the entity."""
         return [str(getattr(self, key)) for key in self.primary_keys]
+
+    @cached_property
+    def relationships(self) -> list[Relationship]:
+        """Get the relationships of the entity."""
+        return inspect(self).mapper.relationships.values()

--- a/src/athlon_flex_notifier/models/option.py
+++ b/src/athlon_flex_notifier/models/option.py
@@ -30,6 +30,6 @@ class Option(BaseModel, table=True):
             "externalId": option_base.externalId,
             "optionName": option_base.optionName,
             "included": option_base.included,
-            "vehicle": vehicle,
+            "vehicle_id": vehicle.id,
         }
         return Option(**data)

--- a/src/athlon_flex_notifier/models/vehicle_availability.py
+++ b/src/athlon_flex_notifier/models/vehicle_availability.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import ForeignKeyConstraint
+from sqlalchemy import DateTime, ForeignKeyConstraint
 from sqlmodel import Field, Relationship
 
 from athlon_flex_notifier.models.base_model import BaseModel
@@ -18,12 +18,17 @@ class VehicleAvailability(BaseModel, table=True):
 
     __tablename__ = "vehicle_availability"
 
-    id: int | None = Field(primary_key=True, default=None)
-    make: str
-    model: str
+    make: str = Field(primary_key=True)
+    model: str = Field(primary_key=True)
     vehicle_id: str = Field(foreign_key="vehicle.id")
-    available_since: datetime
-    available_until: datetime | None = None
+    available_since: datetime | None = Field(
+        primary_key=True,
+        sa_type=DateTime(timezone=True),
+    )
+    available_until: datetime | None = Field(
+        sa_type=DateTime(timezone=True),
+    )
+
     notified: bool = False
     vehicle_cluster: VehicleCluster = Relationship(
         sa_relationship_kwargs={

--- a/src/athlon_flex_notifier/models/vehicle_cluster.py
+++ b/src/athlon_flex_notifier/models/vehicle_cluster.py
@@ -69,19 +69,23 @@ class VehicleCluster(BaseModel, table=True):
         return vehicle_cluster
 
     @classmethod
-    def from_base(cls, *vehicle_clusters: VehicleClusterBase) -> list["VehicleCluster"]:
+    def from_base(
+        cls, *vehicle_cluster_bases: VehicleClusterBase
+    ) -> list["VehicleCluster"]:
         """Create instances and upsert them."""
         vehicle_clusters = [
-            cls._from_base(vehicle_cluster) for vehicle_cluster in vehicle_clusters
+            cls._from_base(vehicle_cluster) for vehicle_cluster in vehicle_cluster_bases
         ]
-        cls.upsert(*vehicle_clusters)
+        vehicle_clusters_upserted = cls.upsert(*vehicle_clusters)
         vehicles = [
             vehicle for cluster in vehicle_clusters for vehicle in cluster.vehicles
         ]
         Vehicle.upsert(*vehicles)
         options = [option for vehicle in vehicles for option in vehicle.options]
         Option.upsert(*options)
-        return vehicle_clusters
+        return VehicleCluster.get(
+            key_hashes=[cluster.key_hash for cluster in vehicle_clusters_upserted]
+        )
 
     @property
     def is_available(self) -> bool:

--- a/src/athlon_flex_notifier/models/vehicle_cluster.py
+++ b/src/athlon_flex_notifier/models/vehicle_cluster.py
@@ -4,6 +4,7 @@ from athlon_flex_api.models.vehicle_cluster import VehicleCluster as VehicleClus
 from sqlmodel import Field, Relationship
 
 from athlon_flex_notifier.models.base_model import BaseModel
+from athlon_flex_notifier.models.option import Option
 from athlon_flex_notifier.models.vehicle import Vehicle
 
 if TYPE_CHECKING:
@@ -70,7 +71,17 @@ class VehicleCluster(BaseModel, table=True):
     @classmethod
     def from_base(cls, *vehicle_clusters: VehicleClusterBase) -> list["VehicleCluster"]:
         """Create instances and upsert them."""
-        return cls.upsert(*[cls._from_base(base) for base in vehicle_clusters])
+        vehicle_clusters = [
+            cls._from_base(vehicle_cluster) for vehicle_cluster in vehicle_clusters
+        ]
+        cls.upsert(*vehicle_clusters)
+        vehicles = [
+            vehicle for cluster in vehicle_clusters for vehicle in cluster.vehicles
+        ]
+        Vehicle.upsert(*vehicles)
+        options = [option for vehicle in vehicles for option in vehicle.options]
+        Option.upsert(*options)
+        return vehicle_clusters
 
     @property
     def is_available(self) -> bool:

--- a/src/athlon_flex_notifier/notifications/notifiers.py
+++ b/src/athlon_flex_notifier/notifications/notifiers.py
@@ -19,7 +19,6 @@ class Notifiers:
         self.logger = logger
 
     def notify(self) -> bool:
-        return True
         if not self.vehicle_clusters:
             self.logger.info("No new vehicles are available.")
             return True

--- a/src/athlon_flex_notifier/notifications/notifiers.py
+++ b/src/athlon_flex_notifier/notifications/notifiers.py
@@ -19,6 +19,7 @@ class Notifiers:
         self.logger = logger
 
     def notify(self) -> bool:
+        return True
         if not self.vehicle_clusters:
             self.logger.info("No new vehicles are available.")
             return True

--- a/src/athlon_flex_notifier/utils.py
+++ b/src/athlon_flex_notifier/utils.py
@@ -3,16 +3,15 @@
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from logging import Logger
 
 from kink import inject
-from pytz import timezone
 
 
 def now() -> datetime:
     """Get now in Amsterdam timezone."""
-    return datetime.now(tz=timezone("Europe/Amsterdam"))
+    return datetime.now(timezone.utc)
 
 
 @contextmanager

--- a/src/athlon_flex_notifier/utils.py
+++ b/src/athlon_flex_notifier/utils.py
@@ -10,7 +10,7 @@ from kink import inject
 
 
 def now() -> datetime:
-    """Get now in Amsterdam timezone."""
+    """Get now in UTC."""
     return datetime.now(timezone.utc)
 
 

--- a/src/athlon_flex_notifier/vehicle_availability_service.py
+++ b/src/athlon_flex_notifier/vehicle_availability_service.py
@@ -36,7 +36,7 @@ class VehicleAvailabilityServices:
         for vehicle_cluster in self._currently_available_clusters:
             for vehicle in vehicle_cluster.vehicles:
                 if availability := vehicle.active_availability:
-                    del availabilities_to_deactivate[availability.id]
+                    del availabilities_to_deactivate[availability.key_hash]
                     continue
                 create_availabilities_for.append(vehicle)
         VehicleAvailability.from_vehicles(*create_availabilities_for)
@@ -55,7 +55,7 @@ class VehicleAvailabilityServices:
                 )
             ).vehicle_clusters
         with time_it("Upserting clusters"):
-            clusters = VehicleCluster.from_base(*base_clusters)
+            clusters = VehicleCluster.from_base(*base_clusters[:1])
         self.logger.info(
             "Found %s clusters; %s vehicles;",
             len(base_clusters),
@@ -66,7 +66,7 @@ class VehicleAvailabilityServices:
     @property
     def _existing_availabilities(self) -> dict[int, VehicleAvailability]:
         return {
-            availability.id: availability
+            availability.key_hash: availability
             for availability in VehicleAvailability.all()
             if availability.is_currently_available
         }

--- a/src/athlon_flex_notifier/vehicle_availability_service.py
+++ b/src/athlon_flex_notifier/vehicle_availability_service.py
@@ -55,7 +55,7 @@ class VehicleAvailabilityServices:
                 )
             ).vehicle_clusters
         with time_it("Upserting clusters"):
-            clusters = VehicleCluster.from_base(*base_clusters[:1])
+            clusters = VehicleCluster.from_base(*base_clusters)
         self.logger.info(
             "Found %s clusters; %s vehicles;",
             len(base_clusters),


### PR DESCRIPTION
**This PR changes the structure of all tables. It can only be deployed by rebuilding the database**

Several issues fixed in upsert mechanism:
- timezone issues in created_at and updated_at
- add computed key_hash and attribute_hash
    - Not yet used for comparison or scd2. will use in future
- make sure upsert() return updated values
- make sure usert uses insert.onconflict, instead of merge().
    - merge deletes entities which are not in the relationship list. For example: if a vehicle is currently not in the cluster, it was removed from db. Instead, insert.onconflict on each entity separately