### PR TITLE
Support filter parameters in the notify deployment and flow

### DIFF
--- a/src/athlon_flex_notifier/bootstrap.py
+++ b/src/athlon_flex_notifier/bootstrap.py
@@ -75,6 +75,7 @@ def _get_logger(name: str) -> logging.Logger:
     If we can get the prefect logger (we are running in a prefect flow), use it
     If not, create a new logger.
     """
+    logging.basicConfig(level=logging.DEBUG)
     try:
         logger = get_run_logger()
     except MissingContextError:

--- a/src/athlon_flex_notifier/bootstrap.py
+++ b/src/athlon_flex_notifier/bootstrap.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm.session import ORMExecuteState
 from sqlmodel import Session
 
 from athlon_flex_notifier.models.tables.base_table import BaseTable
+from athlon_flex_notifier.services.filter_service import FilterService
 
 
 def load_env() -> None:
@@ -36,6 +37,7 @@ def bootstrap_di() -> None:
     di[smtplib.SMTP] = lambda _: _smpt_server()
     # Use factory, to retry getting the prefect logger each time
     di.factories[Logger] = lambda _: _get_logger(__name__)
+    di[FilterService] = lambda _: FilterService()
 
 
 def database_url() -> str:

--- a/src/athlon_flex_notifier/flows.py
+++ b/src/athlon_flex_notifier/flows.py
@@ -2,14 +2,11 @@ from kink import di
 from prefect import flow, serve
 from prefect.client.schemas.schedules import CronSchedule
 from prefect.events import DeploymentEventTrigger
-from logging import Logger
 
 from athlon_flex_notifier.notifications.notifiers import Notifiers
 from athlon_flex_notifier.refresher import (
     Refresher,
 )
-from athlon_flex_notifier.services.filter_service import FilterService
-from pydantic import ValidationError
 
 
 @flow
@@ -19,17 +16,17 @@ def refresh() -> None:
 
 
 @flow
-def notify(filter_parameters: dict | None = None) -> None:
-    """Notify the user about new vehicles."""
-    logger = di[Logger]
-    if filter_parameters:
-        logger.info(f"Filter parameters provided: {filter_parameters}")
-        try:
-            FilterService.validate_filter_parameters(filter_parameters)
-        except ValidationError as e:
-            logger.error(f"Invalid filter parameters: {e}")
-            return
-    di[Notifiers](filter_parameters=filter_parameters).notify()
+def notify(filters: dict | None = None) -> None:
+    """Notify the user about new vehicles.
+
+    Parameters
+    ----------
+    filters : dict, optional
+        Optional filters to apply to the vehicles. Keys must be present in the Vehicle.
+        Values will be filtered using regex.
+
+    """
+    Notifiers(filters=filters).notify()
 
 
 def work() -> None:

--- a/src/athlon_flex_notifier/models/tables/vehicle.py
+++ b/src/athlon_flex_notifier/models/tables/vehicle.py
@@ -5,7 +5,6 @@ from athlon_flex_client.models.vehicle import Vehicle as VehicleBase
 from sqlmodel import Field, Relationship
 
 from athlon_flex_notifier.models.tables.base_table import BaseTable
-from pydantic.schema import schema
 
 if TYPE_CHECKING:
     from athlon_flex_notifier.models.tables.option import Option
@@ -156,8 +155,3 @@ class Vehicle(BaseTable, table=True):
 
     def __str__(self) -> str:
         return f"{self.make} {self.model} {self.color} {self.model_year}"
-
-    @staticmethod
-    def to_json_schema() -> dict:
-        """Convert the Vehicle model to a JSON schema."""
-        return schema([Vehicle], ref_prefix="#/components/schemas/")["definitions"]["Vehicle"]

--- a/src/athlon_flex_notifier/models/tables/vehicle.py
+++ b/src/athlon_flex_notifier/models/tables/vehicle.py
@@ -5,6 +5,7 @@ from athlon_flex_client.models.vehicle import Vehicle as VehicleBase
 from sqlmodel import Field, Relationship
 
 from athlon_flex_notifier.models.tables.base_table import BaseTable
+from pydantic.schema import schema
 
 if TYPE_CHECKING:
     from athlon_flex_notifier.models.tables.option import Option
@@ -155,3 +156,8 @@ class Vehicle(BaseTable, table=True):
 
     def __str__(self) -> str:
         return f"{self.make} {self.model} {self.color} {self.model_year}"
+
+    @staticmethod
+    def to_json_schema() -> dict:
+        """Convert the Vehicle model to a JSON schema."""
+        return schema([Vehicle], ref_prefix="#/components/schemas/")["definitions"]["Vehicle"]

--- a/src/athlon_flex_notifier/models/tables/vehicle_cluster.py
+++ b/src/athlon_flex_notifier/models/tables/vehicle_cluster.py
@@ -9,8 +9,6 @@ from athlon_flex_notifier.models.tables.base_table import BaseTable
 from athlon_flex_notifier.models.tables.vehicle import Vehicle
 from athlon_flex_notifier.upserter import Upserter
 from athlon_flex_notifier.utils import time_it
-from pydantic import BaseModel
-from pydantic.schema import schema
 
 
 class VehicleCluster(BaseTable, table=True):
@@ -145,8 +143,3 @@ class VehicleCluster(BaseTable, table=True):
 
     def __str__(self) -> str:
         return f"{self.make} {self.model}"
-
-    @staticmethod
-    def to_json_schema() -> dict:
-        """Convert the VehicleCluster model to a JSON schema."""
-        return schema([VehicleCluster], ref_prefix="#/components/schemas/")["definitions"]["VehicleCluster"]

--- a/src/athlon_flex_notifier/models/tables/vehicle_cluster.py
+++ b/src/athlon_flex_notifier/models/tables/vehicle_cluster.py
@@ -9,6 +9,8 @@ from athlon_flex_notifier.models.tables.base_table import BaseTable
 from athlon_flex_notifier.models.tables.vehicle import Vehicle
 from athlon_flex_notifier.upserter import Upserter
 from athlon_flex_notifier.utils import time_it
+from pydantic import BaseModel
+from pydantic.schema import schema
 
 
 class VehicleCluster(BaseTable, table=True):
@@ -143,3 +145,8 @@ class VehicleCluster(BaseTable, table=True):
 
     def __str__(self) -> str:
         return f"{self.make} {self.model}"
+
+    @staticmethod
+    def to_json_schema() -> dict:
+        """Convert the VehicleCluster model to a JSON schema."""
+        return schema([VehicleCluster], ref_prefix="#/components/schemas/")["definitions"]["VehicleCluster"]

--- a/src/athlon_flex_notifier/notifications/notifiers.py
+++ b/src/athlon_flex_notifier/notifications/notifiers.py
@@ -9,24 +9,31 @@ from athlon_flex_notifier.models.views.vehicle_availability import VehicleAvaila
 from athlon_flex_notifier.notifications.console_notifier import ConsoleNotifier
 from athlon_flex_notifier.notifications.email_notifier import EmailNotifier
 from athlon_flex_notifier.notifications.notifier import Notifier
-from athlon_flex_notifier.upserter import Upserter
 from athlon_flex_notifier.services.filter_service import FilterService
+from athlon_flex_notifier.upserter import Upserter
 
 
-@inject
 class Notifiers:
     """Run multiple notifiers, and mark all notified."""
 
     notifiers: list[Notifier]
     logger: Logger
     upserter: Upserter
-    filter_parameters: dict | None
+    filter_service: FilterService
+    filters: dict | None
 
     @inject
-    def __init__(self, logger: Logger, upserter: Upserter, filter_parameters: dict | None = None) -> None:
+    def __init__(
+        self,
+        logger: Logger,
+        upserter: Upserter,
+        filter_service: FilterService,
+        filters: dict | None = None,
+    ) -> "Notifiers":
         self.logger = logger
         self.upserter = upserter
-        self.filter_parameters = filter_parameters
+        self.filter_service = filter_service
+        self.filters = filters
 
     def notify(self) -> bool:
         if not self.vehicle_clusters:
@@ -54,21 +61,23 @@ class Notifiers:
 
     @cached_property
     def vehicle_clusters(self) -> list[VehicleCluster]:
-        clusters = list(
+        return list(
             {
                 availability.vehicle.vehicle_cluster.key_hash: availability.vehicle.vehicle_cluster  # noqa: E501
                 for availability in self.availabilities_to_notify
             }.values()
         )
-        if self.filter_parameters:
-            clusters = FilterService.filter_vehicle_clusters(clusters, self.filter_parameters.get("vehicle_cluster", {}))
-        return clusters
 
     @cached_property
     def availabilities_to_notify(self) -> list[VehicleAvailability]:
         availabilities = VehicleAvailability.to_notify()
-        if self.filter_parameters:
-            vehicles = [availability.vehicle for availability in availabilities]
-            filtered_vehicles = FilterService.filter_vehicles(vehicles, self.filter_parameters.get("vehicle", {}))
-            availabilities = [availability for availability in availabilities if availability.vehicle in filtered_vehicles]
-        return availabilities
+        filtered_availabilities = self.filter_service.filter_vehicle_availabilities(
+            availabilities, self.filters
+        )
+        if len(availabilities) != len(filtered_availabilities):
+            self.logger.debug(
+                "Filtered %s vehicle availabilities out of %s",
+                len(availabilities) - len(filtered_availabilities),
+                len(availabilities),
+            )
+        return filtered_availabilities

--- a/src/athlon_flex_notifier/services/filter_service.py
+++ b/src/athlon_flex_notifier/services/filter_service.py
@@ -1,0 +1,64 @@
+from typing import Any, Dict, List
+
+from pydantic import BaseModel, ValidationError
+from pydantic.schema import schema
+
+from athlon_flex_notifier.models.tables.vehicle import Vehicle
+from athlon_flex_notifier.models.tables.vehicle_cluster import VehicleCluster
+from logging import Logger
+from kink import inject
+
+
+@inject
+class FilterService:
+    logger: Logger
+
+    def __init__(self, logger: Logger) -> None:
+        self.logger = logger
+
+    def filter_vehicle_clusters(
+        self, vehicle_clusters: List[VehicleCluster], filter_parameters: Dict[str, Any]
+    ) -> List[VehicleCluster]:
+        filtered_clusters = []
+        for cluster in vehicle_clusters:
+            if self._apply_filter(cluster, filter_parameters):
+                filtered_clusters.append(cluster)
+        self.logger.info(f"Filtered {len(vehicle_clusters) - len(filtered_clusters)} vehicle clusters out of {len(vehicle_clusters)}")
+        return filtered_clusters
+
+    def filter_vehicles(
+        self, vehicles: List[Vehicle], filter_parameters: Dict[str, Any]
+    ) -> List[Vehicle]:
+        filtered_vehicles = []
+        for vehicle in vehicles:
+            if self._apply_filter(vehicle, filter_parameters):
+                filtered_vehicles.append(vehicle)
+        self.logger.info(f"Filtered {len(vehicles) - len(filtered_vehicles)} vehicles out of {len(vehicles)}")
+        return filtered_vehicles
+
+    def _apply_filter(self, obj: Any, filter_parameters: Dict[str, Any]) -> bool:
+        for key, value in filter_parameters.items():
+            if not hasattr(obj, key) or getattr(obj, key) != value:
+                return False
+        return True
+
+    def validate_filter_parameters(self, filter_parameters: Dict[str, Any]) -> None:
+        vehicle_schema = self._generate_schema(Vehicle)
+        vehicle_cluster_schema = self._generate_schema(VehicleCluster)
+        combined_schema = {
+            "type": "object",
+            "properties": {
+                "vehicle": vehicle_schema,
+                "vehicle_cluster": vehicle_cluster_schema,
+            },
+        }
+        try:
+            BaseModel.parse_obj(filter_parameters, combined_schema)
+        except ValidationError as e:
+            self.logger.error(f"Invalid filter parameters: {e}")
+            raise e
+
+    def _generate_schema(self, model: BaseModel) -> Dict[str, Any]:
+        return schema([model], ref_prefix="#/components/schemas/")["definitions"][
+            model.__name__
+        ]

--- a/src/athlon_flex_notifier/services/filter_service.py
+++ b/src/athlon_flex_notifier/services/filter_service.py
@@ -1,64 +1,47 @@
-from typing import Any, Dict, List
-
-from pydantic import BaseModel, ValidationError
-from pydantic.schema import schema
-
-from athlon_flex_notifier.models.tables.vehicle import Vehicle
-from athlon_flex_notifier.models.tables.vehicle_cluster import VehicleCluster
+import re
 from logging import Logger
+from typing import Any
+
 from kink import inject
+
+from athlon_flex_notifier.models.tables.base_table import BaseTable
+from athlon_flex_notifier.models.views.vehicle_availability import VehicleAvailability
 
 
 @inject
 class FilterService:
+    """Filter service. Can filter vehicle availabilities based on a filter dict."""
+
     logger: Logger
 
+    @inject
     def __init__(self, logger: Logger) -> None:
         self.logger = logger
 
-    def filter_vehicle_clusters(
-        self, vehicle_clusters: List[VehicleCluster], filter_parameters: Dict[str, Any]
-    ) -> List[VehicleCluster]:
-        filtered_clusters = []
-        for cluster in vehicle_clusters:
-            if self._apply_filter(cluster, filter_parameters):
-                filtered_clusters.append(cluster)
-        self.logger.info(f"Filtered {len(vehicle_clusters) - len(filtered_clusters)} vehicle clusters out of {len(vehicle_clusters)}")
-        return filtered_clusters
+    def filter_vehicle_availabilities(
+        self,
+        vehicle_availabilities: list[VehicleAvailability],
+        filters: dict[str, Any] | None = None,
+    ) -> list[VehicleAvailability]:
+        filters = filters or {}
+        return [
+            availability
+            for availability in vehicle_availabilities
+            if self.table_matches_filter(availability.vehicle, filters)
+        ]
 
-    def filter_vehicles(
-        self, vehicles: List[Vehicle], filter_parameters: Dict[str, Any]
-    ) -> List[Vehicle]:
-        filtered_vehicles = []
-        for vehicle in vehicles:
-            if self._apply_filter(vehicle, filter_parameters):
-                filtered_vehicles.append(vehicle)
-        self.logger.info(f"Filtered {len(vehicles) - len(filtered_vehicles)} vehicles out of {len(vehicles)}")
-        return filtered_vehicles
-
-    def _apply_filter(self, obj: Any, filter_parameters: Dict[str, Any]) -> bool:
-        for key, value in filter_parameters.items():
-            if not hasattr(obj, key) or getattr(obj, key) != value:
+    def table_matches_filter(self, table: BaseTable, filters: dict[str, Any]) -> bool:
+        for key, value in filters.items():
+            if not hasattr(table, key):
+                self.logger.warning("Model %s does not have attribute %s", table, key)
+                return False
+            if not re.match(value, getattr(table, key)):
+                self.logger.debug(
+                    "Model %s (%s) does not match filter %s=%s",
+                    table,
+                    table.compute_key_hash(),
+                    key,
+                    value,
+                )
                 return False
         return True
-
-    def validate_filter_parameters(self, filter_parameters: Dict[str, Any]) -> None:
-        vehicle_schema = self._generate_schema(Vehicle)
-        vehicle_cluster_schema = self._generate_schema(VehicleCluster)
-        combined_schema = {
-            "type": "object",
-            "properties": {
-                "vehicle": vehicle_schema,
-                "vehicle_cluster": vehicle_cluster_schema,
-            },
-        }
-        try:
-            BaseModel.parse_obj(filter_parameters, combined_schema)
-        except ValidationError as e:
-            self.logger.error(f"Invalid filter parameters: {e}")
-            raise e
-
-    def _generate_schema(self, model: BaseModel) -> Dict[str, Any]:
-        return schema([model], ref_prefix="#/components/schemas/")["definitions"][
-            model.__name__
-        ]


### PR DESCRIPTION
Generated by Copilot Workspace, needs revision and testing. 

Add support for filter parameters in the "notify" flow to filter vehicle clusters and vehicles based on optional JSON parameters.

* **Flows**:
  - Add an optional `filter_parameters` parameter to the `notify` flow in `src/athlon_flex_notifier/flows.py`.
  - Validate the `filter_parameters` against a dynamically deduced JSON schema at the start of the `notify` flow.
  - Pass the `filter_parameters` to the `Notifiers` class.

* **Notifiers**:
  - Add an optional `filter_parameters` parameter to the `Notifiers` class in `src/athlon_flex_notifier/notifications/notifiers.py`.
  - Implement methods to filter `vehicle_clusters` and `availabilities_to_notify` based on `filter_parameters`.
  - Ensure `filter_vehicles` function receives a list of `Vehicle` instead of `VehicleAvailability`.

* **FilterService**:
  - Implement a `FilterService` class in `src/athlon_flex_notifier/services/filter_service.py` to apply JSON filters to `vehicle` and `vehicle_cluster`.
  - Implement methods to validate the filter against a dynamically deduced JSON schema based on pydantic models.
  - Move logging into the `FilterService` class.

* **Bootstrap**:
  - Register the `FilterService` in the dependency injection container in `src/athlon_flex_notifier/bootstrap.py`.

* **Models**:
  - Add methods to convert the `VehicleCluster` and `Vehicle` models to JSON schemas in `src/athlon_flex_notifier/models/tables/vehicle_cluster.py` and `src/athlon_flex_notifier/models/tables/vehicle.py`.
  - Remove duplicate `to_json_schema` definitions in `src/athlon_flex_notifier/models/tables/base_table.py`.

